### PR TITLE
[refactor] 로그인 로직 정리

### DIFF
--- a/src/main/java/org/board/exercise_board/exception/ErrorCode.java
+++ b/src/main/java/org/board/exercise_board/exception/ErrorCode.java
@@ -15,6 +15,9 @@ public enum ErrorCode {
   LOGIN_ID_IS_NULL(HttpStatus.BAD_REQUEST, "ID는 필수 입력 항목입니다."),
   PASSWORD_IS_NULL(HttpStatus.BAD_REQUEST, "비밀번호는 필수 입력 항목입니다."),
 
+  // 로그인 관련
+  NOT_MATCHED_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
+
   // 인증 관련
   NOT_FOUND_USER(HttpStatus.BAD_REQUEST, "해당 사용자를 찾을 수 없습니다."),
   ALREADY_VERIFIED(HttpStatus.BAD_REQUEST, "이미 인증이 완료되었습니다."),


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- UserService에서 AuthenticationManagerBuilder 사용하여 Authentication 객체 생성
  - 불필요하다고 판단함
- JWT Token 생성 시 Authentication 객체 사용
  - Authentication 객체를 생성하는 불필요한 과정 발생

**TO-BE**
- UserService 에서 AuthenticationManagerBuilder 객체 사용 삭제
- 로그인 시 authentication 객체 생성 -> passwordencoder를 사용해서 비밀번호 일치 여부 확인
  - UserService에서 Authentication 객체 생성은 불필요하다고 판단

- Token 생성 시 발행일시 payload에 추가 설정